### PR TITLE
Fix octals for array conversion

### DIFF
--- a/src/functions/array.php
+++ b/src/functions/array.php
@@ -39,7 +39,8 @@ function to_javascript_object(array $arr, $sequential_keys = false, $quote_keys 
 		else if (is_bool($value)) {
 			$output .= ($value ? 'true' : 'false');
 		}
-		else if (is_numeric($value)) {
+		// Check for octal notation beginning with 0 in addition to is_numeric()
+		else if (is_numeric($value) && strpos($value, "0") !== 0) {
 			$output .= $value;
 		}
 		else {


### PR DESCRIPTION
- Treat numbers with leading 0s as strings, otherwise they will be output as octals and converted to a different decimal than you are expecting when used as a number.