### PR TITLE
0 values on json_encode_numeric

### DIFF
--- a/src/functions/json.php
+++ b/src/functions/json.php
@@ -34,7 +34,7 @@ function json_encode_numeric($value, $options = 0, $depth = 512): string {
 function json_parse_numeric(&$value) {
 	if (is_string($value) && is_numeric($value)) {
 		// check if value doesn't starts with 0 or +
-		if (!preg_match('/^[0\+]+/', $value)) {
+		if (!preg_match('/^[0\+]+/', $value) || $value === "0") {
 			// cast $value to int or float
 			$value += 0;
 		}


### PR DESCRIPTION
- Account for '0' exact string values when running `json_encode_numeric` which should be parsed as an int despite beginning with '0'