### PR TITLE
test: string methods

### DIFF
--- a/tests/phpunit/Integration/ExampleTest.php
+++ b/tests/phpunit/Integration/ExampleTest.php
@@ -3,7 +3,19 @@
 namespace Cig\Tests\Integration;
 
 class ExampleTest extends \Cig\Tests\Integration\BaseTestCase {
+	/**
+	 * Optional. Prepares the test environment before each test.
+	 */
 	protected function setUp(): void {
 		parent::setUp();
+	}
+
+	/**
+	 * A basic test example.
+	 *
+	 * @return void
+	 */
+	public function test_example(): void {
+		self::assertTrue(TRUE);
 	}
 }

--- a/tests/phpunit/Unit/ExampleTest.php
+++ b/tests/phpunit/Unit/ExampleTest.php
@@ -3,7 +3,19 @@
 namespace Cig\Tests\Unit;
 
 class ExampleTest extends \Cig\Tests\Unit\BaseTestCase {
+	/**
+	 * Optional. Prepares the test environment before each test.
+	 */
 	protected function setUp(): void {
 		parent::setUp();
+	}
+
+	/**
+	 * A basic test example.
+	 *
+	 * @return void
+	 */
+	public function test_example(): void {
+		self::assertTrue(TRUE);
 	}
 }

--- a/tests/phpunit/Unit/functions/StrToCamelCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToCamelCaseTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Cig\Tests\Unit;
+
+class StrToCamelCaseTest extends \Cig\Tests\Unit\BaseTestCase {
+
+	public function test_str_to_camel_case(): void {
+		$string = "welcome~ to camel' case!!";
+		$expected_result = "welcomeToCamelCase";
+
+		//this method uses another method (str_to_words) from same file (string.php)
+		$result = \Cig\str_to_camel_case($string);
+
+		self::assertIsString($result);
+		self::assertSame($expected_result, $result);
+		// skipping international alphabet tests
+	}
+
+	//TODO: expected this to break but this method goes ahead and turns
+	// numbers into strings despite typescript asking for a string
+	public function test_number_to_camel_case(): void {
+		$not_a_string = 101;
+		// $expected_result = don't expect a result;
+
+		// TODO: showing test with string result to document. correct or add refactor note?
+		$method_result = '101';
+		$result = \Cig\str_to_camel_case($not_a_string);
+
+		self::assertSame($method_result, $result);
+	}
+}

--- a/tests/phpunit/Unit/functions/StrToKebabCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToKebabCaseTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Cig\Tests\Unit;
+
+class StrToKebabCaseTest extends \Cig\Tests\Unit\BaseTestCase {
+
+	public function test_str_to_kebab_case(): void {
+		$string = "welcome~ to *kebab case!!";
+		$expected_result = "welcome-to-kebab-case";
+
+		//this method uses another method (str_to_words) from same file
+		$result = \Cig\str_to_kebab_case($string);
+
+		self::assertIsString($result);
+		self::assertSame($expected_result, $result);
+	}
+
+	//TODO: expected this to break but this method goes ahead and turns
+	// numbers into strings despite typescript asking for a string
+	public function test_number_to_kebab_case(): void {
+		$not_a_string = 1011;
+		// $expected_result = "don't expect result";
+
+		// TODO: showing test with string result to document. correct or refactor?
+		$method_result = '1011';
+
+		$result = \Cig\str_to_kebab_case($not_a_string);
+
+		self::assertIsString($result);
+		self::assertSame($method_result, $result);
+	}
+}

--- a/tests/phpunit/Unit/functions/StrToPascalCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToPascalCaseTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Cig\Tests\Unit;
+
+class StrToPascalCaseTest extends \Cig\Tests\Unit\BaseTestCase {
+
+	public function test_str_to_pascal_case(): void {
+		$string = "welcome~ to *pascal case!!";
+		$expected_result = "WelcomeToPascalCase";
+
+		//this method uses another method (str_to_words) from same file
+		$result = \Cig\str_to_pascal_case($string);
+
+		self::assertIsString($result);
+		self::assertSame($expected_result, $result);
+	}
+
+	//TODO: expected this to break but this method goes ahead and turns
+	// numbers into strings despite typescript asking for a string
+	public function test_number_to_pascal_case(): void {
+		$not_a_string = 1011;
+		// $expected_result = "don't expect result";
+
+		// TODO: showing test with string result to document. correct or refactor?
+		$method_result = '1011';
+
+		$result = \Cig\str_to_pascal_case($not_a_string);
+
+		self::assertIsString($result);
+		self::assertSame($method_result, $result);
+	}
+}

--- a/tests/phpunit/Unit/functions/StrToSnakeCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToSnakeCaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Cig\Tests\Unit;
+
+class StrToSnakeCaseTest extends \Cig\Tests\Unit\BaseTestCase {
+
+	public function test_str_to_snake_case(): void {
+		$string = "welcome~ to *snake case!!";
+		$expected_result = "welcome_to_snake_case";
+
+		//this method uses another method (str_to_words) from same file
+		$result = \Cig\str_to_snake_case($string);
+
+		self::assertIsString($result);
+		self::assertSame($expected_result, $result);
+	}
+}


### PR DESCRIPTION
initial tests for first few methods in `string.php`, pushed together for recurring question/issue popping up.

### review questions!
- question comments across files are the same/similar as the first file (camel case tests). mostly re: passing integers into 'string' typestript arguments and whether that should be refactored to fail (or make a note to change) or just be accepted as is? feels like a betrayal of trust from typescript tbh
- also should `str_to_words` (string.php) be stubbed?

<img src="https://media1.giphy.com/media/IRZE8JX2BQikM/giphy.gif" alt="corpo jack"/>