### PR TITLE
test: is_assoc

### DIFF
--- a/tests/phpunit/Integration/ExampleTest.php
+++ b/tests/phpunit/Integration/ExampleTest.php
@@ -3,7 +3,19 @@
 namespace Cig\Tests\Integration;
 
 class ExampleTest extends \Cig\Tests\Integration\BaseTestCase {
+	/**
+	 * Optional. Prepares the test environment before each test.
+	 */
 	protected function setUp(): void {
 		parent::setUp();
+	}
+
+	/**
+	 * A basic test example.
+	 *
+	 * @return void
+	 */
+	public function test_example(): void {
+		self::assertTrue(TRUE);
 	}
 }

--- a/tests/phpunit/Unit/ExampleTest.php
+++ b/tests/phpunit/Unit/ExampleTest.php
@@ -3,7 +3,19 @@
 namespace Cig\Tests\Unit;
 
 class ExampleTest extends \Cig\Tests\Unit\BaseTestCase {
+	/**
+	 * Optional. Prepares the test environment before each test.
+	 */
 	protected function setUp(): void {
 		parent::setUp();
+	}
+
+	/**
+	 * A basic test example.
+	 *
+	 * @return void
+	 */
+	public function test_example(): void {
+		self::assertTrue(TRUE);
 	}
 }

--- a/tests/phpunit/Unit/functions/Br2nlTest.php
+++ b/tests/phpunit/Unit/functions/Br2nlTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Cig\Tests\Unit\Functions;
+
+//TODO: string helpers are really stepping on each other in string.php
+
+class Br2nlTest extends \Cig\Tests\Unit\BaseTestCase {
+
+	public function test_br2nl(): void {
+		$string = 'here is a <br />line break';
+		$expected_result = 'here is a 
+line break';
+
+		$result = \Cig\br2nl($string);
+
+		self::assertSame($expected_result, $result);
+
+		self::assertTrue(TRUE);
+	}
+}

--- a/tests/phpunit/Unit/functions/Br2nlTest.php
+++ b/tests/phpunit/Unit/functions/Br2nlTest.php
@@ -13,9 +13,8 @@ line break';
 
 		$result = \Cig\br2nl($string);
 
+		self::assertIsString($result);
 		self::assertSame($expected_result, $result);
-
-		self::assertTrue(TRUE);
 	}
 
 	public function test_br_no_whack(): void {

--- a/tests/phpunit/Unit/functions/Br2nlTest.php
+++ b/tests/phpunit/Unit/functions/Br2nlTest.php
@@ -17,4 +17,24 @@ line break';
 
 		self::assertTrue(TRUE);
 	}
+
+	public function test_br_no_whack(): void {
+		$string = "here is a <br>line break";
+//		$expected_result = 'here is a
+//line break';
+
+		$result = \Cig\br2nl($string);
+
+		self::markTestSkipped('**WIP** Revisit this test — does not consider br without whack');
+	}
+
+	public function test_br_no_space(): void {
+		$string = "here is a <br>line break";
+//		$expected_result = 'here is a
+//line break';
+
+		$result = \Cig\br2nl($string);
+
+		self::markTestSkipped('**WIP** Revisit this test - does not consider br without space');
+	}
 }

--- a/tests/phpunit/Unit/functions/Br2nlTest.php
+++ b/tests/phpunit/Unit/functions/Br2nlTest.php
@@ -6,6 +6,9 @@ namespace Cig\Tests\Unit\Functions;
 
 class Br2nlTest extends \Cig\Tests\Unit\BaseTestCase {
 
+	/**
+	 * @covers ::\Cig\br2nl()
+	 */
 	public function test_br2nl(): void {
 		$string = 'here is a <br />line break';
 		$expected_result = 'here is a 
@@ -17,9 +20,27 @@ line break';
 		self::assertSame($expected_result, $result);
 	}
 
-	public function test_br_no_whack(): void {
-		$string = "here is a <br>line break";
+	/**
+	 * test <br/> with no space
+	 * @covers ::\Cig\br2nl()
+	 */
+	public function test_br_no_space(): void {
+		$string = "here is a <br/>line break";
 //		$expected_result = 'here is a
+//line break';
+
+		$result = \Cig\br2nl($string);
+
+		self::markTestSkipped('**WIP** Revisit this test - does not consider br without space');
+	}
+
+	/**
+	 * test <br > with no whack
+	 * @covers ::\Cig\br2nl()
+	 */
+	public function test_br_no_whack(): void {
+		$string = "here is a <br >line break";
+		//		$expected_result = 'here is a
 //line break';
 
 		$result = \Cig\br2nl($string);
@@ -27,9 +48,13 @@ line break';
 		self::markTestSkipped('**WIP** Revisit this test — does not consider br without whack');
 	}
 
-	public function test_br_no_space(): void {
+	/**
+	 * test <br> with no space or whack
+	 * @covers ::\Cig\br2nl()
+	 */
+	public function test_br_no_space_no_whack(): void {
 		$string = "here is a <br>line break";
-//		$expected_result = 'here is a
+		//		$expected_result = 'here is a
 //line break';
 
 		$result = \Cig\br2nl($string);

--- a/tests/phpunit/Unit/functions/FilterEmptyStringsFromArrayTest.php
+++ b/tests/phpunit/Unit/functions/FilterEmptyStringsFromArrayTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Cig\Tests\Unit\Functions;
+
+class FilterEmptyStringsFromArrayTest extends \Cig\Tests\Unit\BaseTestCase {
+
+	/**
+	 * @covers ::\Cig\filter_empty_strings_from_array
+	 *
+	 * @param $array
+	 * @param $expected_result
+	 */
+	public function test_filter_empty_strings_from_non_assoc_array(): void {
+		$array = ['dracula', '', 'werewolf'];
+		$expected_result = [0 => 'dracula', 2 => 'werewolf'];
+
+		$result = \Cig\filter_empty_strings_from_array($array);
+
+		self::assertIsArray($result);
+		self::assertSame($expected_result, $result);
+	}
+
+	/**
+	 * @covers ::\Cig\filter_empty_strings_from_array
+	 *
+	 * @param $string
+	 * @param $expected_result
+	 */
+	public function test_filter_empty_strings_from_assoc_array(): void {
+		$array = ['werewolf' => 'full moon', '', 'mummy' => '', 'dracula' => 'castle'];
+		$expected_result = ['werewolf' => 'full moon', 'dracula' => 'castle'];
+
+		$result = \Cig\filter_empty_strings_from_array($array);
+
+		var_dump($result);
+
+		self::assertIsArray($result);
+		self::assertSame($expected_result, $result);
+	}
+}

--- a/tests/phpunit/Unit/functions/FilterEmptyStringsFromArrayTest.php
+++ b/tests/phpunit/Unit/functions/FilterEmptyStringsFromArrayTest.php
@@ -23,7 +23,7 @@ class FilterEmptyStringsFromArrayTest extends \Cig\Tests\Unit\BaseTestCase {
 	/**
 	 * @covers ::\Cig\filter_empty_strings_from_array
 	 *
-	 * @param $string
+	 * @param $array
 	 * @param $expected_result
 	 */
 	public function test_filter_empty_strings_from_assoc_array(): void {
@@ -32,7 +32,21 @@ class FilterEmptyStringsFromArrayTest extends \Cig\Tests\Unit\BaseTestCase {
 
 		$result = \Cig\filter_empty_strings_from_array($array);
 
-		var_dump($result);
+		self::assertIsArray($result);
+		self::assertSame($expected_result, $result);
+	}
+
+	/**
+	 * @covers ::\Cig\filter_empty_strings_from_array
+	 *
+	 * @param $array
+	 * @param $expected_result
+	 */
+	public function test_filter_empty_strings_from_mixed_array(): void {
+		$array = [0 => 'full moon', 1 => '', 'mummy' => '', 'dracula' => 'castle'];
+		$expected_result = [0 => 'full moon', 'dracula' => 'castle'];
+
+		$result = \Cig\filter_empty_strings_from_array($array);
 
 		self::assertIsArray($result);
 		self::assertSame($expected_result, $result);

--- a/tests/phpunit/Unit/functions/FilterEmptyStringsFromArrayTest.php
+++ b/tests/phpunit/Unit/functions/FilterEmptyStringsFromArrayTest.php
@@ -38,10 +38,7 @@ class FilterEmptyStringsFromArrayTest extends \Cig\Tests\Unit\BaseTestCase {
 	 * @param $array
 	 * @param $expected_result
 	 */
-	public function test_filter_empty_strings_from_non_assoc_array($array, $expected_result): void {
-		//		$array = ['dracula', '', 'werewolf'];
-		//		$expected_result = [0 => 'dracula', 2 => 'werewolf'];
-
+	public function test_filter_empty_strings_from_array($array, $expected_result): void {
 		$result = \Cig\filter_empty_strings_from_array($array);
 
 		self::assertIsArray($result);

--- a/tests/phpunit/Unit/functions/FilterEmptyStringsFromArrayTest.php
+++ b/tests/phpunit/Unit/functions/FilterEmptyStringsFromArrayTest.php
@@ -15,16 +15,18 @@ class FilterEmptyStringsFromArrayTest extends \Cig\Tests\Unit\BaseTestCase {
 				//expected result
 				[0 => 'dracula', 2 => 'werewolf'],
 			],
-//			'assoc' => [
-//				//array
-//
-//				//expected result
-//			],
-//			'mixed_array' => [
-//				//array
-//
-//				//expected result
-//			],
+			'assoc' => [
+				//array
+				['werewolf' => 'full moon', '', 'mummy' => '', 'dracula' => 'castle'],
+				//expected result
+				['werewolf' => 'full moon', 'dracula' => 'castle'],
+			],
+			'mixed_array' => [
+				//array
+				[0 => 'full moon', 1 => '', 'mummy' => '', 'dracula' => 'castle'],
+				//expected result
+				[0 => 'full moon', 'dracula' => 'castle'],
+			],
 		];
 	}
 
@@ -32,12 +34,13 @@ class FilterEmptyStringsFromArrayTest extends \Cig\Tests\Unit\BaseTestCase {
 	 * @covers ::\Cig\filter_empty_strings_from_array
 	 *
 	 * @dataProvider provide_empty_string_array_data
+	 *
 	 * @param $array
 	 * @param $expected_result
 	 */
 	public function test_filter_empty_strings_from_non_assoc_array($array, $expected_result): void {
-//		$array = ['dracula', '', 'werewolf'];
-//		$expected_result = [0 => 'dracula', 2 => 'werewolf'];
+		//		$array = ['dracula', '', 'werewolf'];
+		//		$expected_result = [0 => 'dracula', 2 => 'werewolf'];
 
 		$result = \Cig\filter_empty_strings_from_array($array);
 
@@ -45,35 +48,13 @@ class FilterEmptyStringsFromArrayTest extends \Cig\Tests\Unit\BaseTestCase {
 		self::assertSame($expected_result, $result);
 	}
 
-	/**
-	 * @covers ::\Cig\filter_empty_strings_from_array
-	 *
-	 * @param $array
-	 * @param $expected_result
-	 */
-	public function test_filter_empty_strings_from_assoc_array(): void {
-		$array = ['werewolf' => 'full moon', '', 'mummy' => '', 'dracula' => 'castle'];
-		$expected_result = ['werewolf' => 'full moon', 'dracula' => 'castle'];
+	public function test_filter_empty_strings_from_string(): void {
+		$array = 'what we do in the shadows';
+		// $expected_result = 'don't expect a result';
+
+		$this->expectError();
+		$this->expectErrorMessage('Argument 1 passed to Cig\filter_empty_strings_from_array() must be of the type array, string given');
 
 		$result = \Cig\filter_empty_strings_from_array($array);
-
-		self::assertIsArray($result);
-		self::assertSame($expected_result, $result);
-	}
-
-	/**
-	 * @covers ::\Cig\filter_empty_strings_from_array
-	 *
-	 * @param $array
-	 * @param $expected_result
-	 */
-	public function test_filter_empty_strings_from_mixed_array(): void {
-		$array = [0 => 'full moon', 1 => '', 'mummy' => '', 'dracula' => 'castle'];
-		$expected_result = [0 => 'full moon', 'dracula' => 'castle'];
-
-		$result = \Cig\filter_empty_strings_from_array($array);
-
-		self::assertIsArray($result);
-		self::assertSame($expected_result, $result);
 	}
 }

--- a/tests/phpunit/Unit/functions/FilterEmptyStringsFromArrayTest.php
+++ b/tests/phpunit/Unit/functions/FilterEmptyStringsFromArrayTest.php
@@ -50,7 +50,7 @@ class FilterEmptyStringsFromArrayTest extends \Cig\Tests\Unit\BaseTestCase {
 		// $expected_result = 'don't expect a result';
 
 		$this->expectError();
-		$this->expectErrorMessage('Argument 1 passed to Cig\filter_empty_strings_from_array() must be of the type array, string given');
+		$this->expectErrorMessage('Argument #1 ($arr) must be of type array, string given');
 
 		$result = \Cig\filter_empty_strings_from_array($array);
 	}

--- a/tests/phpunit/Unit/functions/FilterEmptyStringsFromArrayTest.php
+++ b/tests/phpunit/Unit/functions/FilterEmptyStringsFromArrayTest.php
@@ -5,14 +5,39 @@ namespace Cig\Tests\Unit\Functions;
 class FilterEmptyStringsFromArrayTest extends \Cig\Tests\Unit\BaseTestCase {
 
 	/**
+	 * @return array[]
+	 */
+	public function provide_empty_string_array_data(): array {
+		return [
+			'non_assoc' => [
+				//array
+				['dracula', '', 'werewolf'],
+				//expected result
+				[0 => 'dracula', 2 => 'werewolf'],
+			],
+//			'assoc' => [
+//				//array
+//
+//				//expected result
+//			],
+//			'mixed_array' => [
+//				//array
+//
+//				//expected result
+//			],
+		];
+	}
+
+	/**
 	 * @covers ::\Cig\filter_empty_strings_from_array
 	 *
+	 * @dataProvider provide_empty_string_array_data
 	 * @param $array
 	 * @param $expected_result
 	 */
-	public function test_filter_empty_strings_from_non_assoc_array(): void {
-		$array = ['dracula', '', 'werewolf'];
-		$expected_result = [0 => 'dracula', 2 => 'werewolf'];
+	public function test_filter_empty_strings_from_non_assoc_array($array, $expected_result): void {
+//		$array = ['dracula', '', 'werewolf'];
+//		$expected_result = [0 => 'dracula', 2 => 'werewolf'];
 
 		$result = \Cig\filter_empty_strings_from_array($array);
 

--- a/tests/phpunit/Unit/functions/IsAssocTest.php
+++ b/tests/phpunit/Unit/functions/IsAssocTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Cig\Tests\Unit\Functions;
+
+class IsAssocTest extends \Cig\Tests\Unit\BaseTestCase {
+
+	/**
+	 * @covers ::\Cig\is_assoc()
+	 */
+	public function test_is_assoc(): void {
+		$array = ['scotland' => 'loch ness', 'greece' => 'hydra', 'mexico' => 'quetzalcoatl'];
+		$expected_result = TRUE;
+
+		$result = \Cig\is_assoc($array);
+
+		self::assertIsBool($result);
+		self::assertSame($expected_result, $result);
+	}
+}

--- a/tests/phpunit/Unit/functions/IsAssocTest.php
+++ b/tests/phpunit/Unit/functions/IsAssocTest.php
@@ -16,4 +16,18 @@ class IsAssocTest extends \Cig\Tests\Unit\BaseTestCase {
 		self::assertIsBool($result);
 		self::assertSame($expected_result, $result);
 	}
+
+
+	/**
+	 * @covers ::\Cig\is_assoc()
+	 */
+	public function test_is_assoc_non_assoc(): void {
+		$array = ['loch ness', 'hydra', 'quetzalcoatl'];
+		$expected_result = FALSE;
+
+		$result = \Cig\is_assoc($array);
+
+		self::assertIsBool($result);
+		self::assertSame($expected_result, $result);
+	}
 }

--- a/tests/phpunit/Unit/functions/IsAssocTest.php
+++ b/tests/phpunit/Unit/functions/IsAssocTest.php
@@ -30,4 +30,20 @@ class IsAssocTest extends \Cig\Tests\Unit\BaseTestCase {
 		self::assertIsBool($result);
 		self::assertSame($expected_result, $result);
 	}
+
+	/**
+	 * TODO: shouldn't this fail?
+	 * @covers ::\Cig\is_assoc()
+	 */
+	public function test_is_assoc_mixed(): void {
+		$array = ['scotland' => 'loch ness', 1 => 'hydra', 2 => 'quetzalcoatl'];
+		$expected_result = TRUE; // ??
+
+		$result = \Cig\is_assoc($array);
+
+		self::markTestSkipped('**WIP** Revisit this test');
+
+		//	self::assertIsBool($result);
+		//	self::assertSame($expected_result, $result);
+	}
 }

--- a/tests/phpunit/Unit/functions/IsAssocTest.php
+++ b/tests/phpunit/Unit/functions/IsAssocTest.php
@@ -46,4 +46,17 @@ class IsAssocTest extends \Cig\Tests\Unit\BaseTestCase {
 		//	self::assertIsBool($result);
 		//	self::assertSame($expected_result, $result);
 	}
+
+	/**
+	 * @covers ::\Cig\is_assoc()
+	 */
+	public function test_is_assoc_not_array(): void {
+		$array = 'loch ness hydra and quetzalcoatl';
+		$expected_result = FALSE;
+
+		$this->expectError();
+		$this->expectErrorMessage('Argument #1 ($arr) must be of type array, string given');
+
+		$result = \Cig\is_assoc($array);
+	}
 }

--- a/tests/phpunit/Unit/functions/StrToCamelCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToCamelCaseTest.php
@@ -40,7 +40,7 @@ class StrToCamelCaseTest extends \Cig\Tests\Unit\BaseTestCase {
 		// $expected_result = don't expect a result;
 
 		$this->expectError();
-		$this->expectErrorMessage('Argument 1 passed to Cig\str_to_camel_case() must be of the type string, int given');
+		$this->expectErrorMessage('Argument #1 ($string) must be of type string, int given');
 
 		$result = \Cig\str_to_camel_case($not_a_string);
 	}

--- a/tests/phpunit/Unit/functions/StrToCamelCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToCamelCaseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Cig\Tests\Unit;
+namespace Cig\Tests\Unit\Functions;
 
 class StrToCamelCaseTest extends \Cig\Tests\Unit\BaseTestCase {
 

--- a/tests/phpunit/Unit/functions/StrToCamelCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToCamelCaseTest.php
@@ -2,11 +2,19 @@
 
 namespace Cig\Tests\Unit;
 
+//TODO: add data provider for all these redundant string tests (in setup?)
+
+
 class StrToCamelCaseTest extends \Cig\Tests\Unit\BaseTestCase {
 
+	/**
+	 * @covers ::\Cig\str_to_camel_case()
+	 */
 	public function test_str_to_camel_case(): void {
 		$string = "welcome~ to camel' case!!";
 		$expected_result = "welcomeToCamelCase";
+//		$string = "D'Angelo";
+//		$expected_result = "dAngelo";
 
 		//this method uses another method (str_to_words) from same file (string.php)
 		$result = \Cig\str_to_camel_case($string);

--- a/tests/phpunit/Unit/functions/StrToCamelCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToCamelCaseTest.php
@@ -1,5 +1,9 @@
 <?php
 
+// NOTE: I don't know why this is necessary to honor typing for
+// test_number_to_camel_case(), but it won't fail properly without it.
+declare(strict_types=1);
+
 namespace Cig\Tests\Unit\Functions;
 
 class StrToCamelCaseTest extends \Cig\Tests\Unit\BaseTestCase {
@@ -31,16 +35,13 @@ class StrToCamelCaseTest extends \Cig\Tests\Unit\BaseTestCase {
 		self::markTestSkipped('**WIP** Revisit this test');
 	}
 
-	//TODO: expected this to break but this method goes ahead and turns
-	// numbers into strings despite typescript asking for a string
 	public function test_number_to_camel_case(): void {
 		$not_a_string = 101;
 		// $expected_result = don't expect a result;
 
-		// TODO: showing test with string result to document. correct or add refactor note?
-		$method_result = '101';
-		$result = \Cig\str_to_camel_case($not_a_string);
+		$this->expectError();
+		$this->expectErrorMessage('Argument 1 passed to Cig\str_to_camel_case() must be of the type string, int given');
 
-		self::assertSame($method_result, $result);
+		$result = \Cig\str_to_camel_case($not_a_string);
 	}
 }

--- a/tests/phpunit/Unit/functions/StrToCamelCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToCamelCaseTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Cig\Tests\Unit;
+
+class StrToCamelCaseTest extends \Cig\Tests\Unit\BaseTestCase {
+
+	public function test_str_to_camel_case(): void {
+		$string = "welcome~ to camel' case!!";
+		$expected_result = "welcomeToCamelCase";
+
+		//this method uses another method (str_to_words) from same file (string.php)
+		$result = \Cig\str_to_camel_case($string);
+
+		self::assertIsString($result);
+		self::assertSame($expected_result, $result);
+		// skipping international alphabet tests
+	}
+
+	//TODO: expected this to break but this method goes ahead and turns
+	// numbers into strings despite typescript asking for a string
+	public function test_number_to_camel_case(): void {
+		$not_a_string = 101;
+		// $expected_result = don't expect a result;
+
+		// TODO: showing test with string result to document. correct or add refactor note?
+		$method_result = '101';
+		$result = \Cig\str_to_camel_case($not_a_string);
+
+		self::assertSame($method_result, $result);
+	}
+}

--- a/tests/phpunit/Unit/functions/StrToCamelCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToCamelCaseTest.php
@@ -2,9 +2,6 @@
 
 namespace Cig\Tests\Unit;
 
-//TODO: add data provider for all these redundant string tests (in setup?)
-
-
 class StrToCamelCaseTest extends \Cig\Tests\Unit\BaseTestCase {
 
 	/**
@@ -13,15 +10,25 @@ class StrToCamelCaseTest extends \Cig\Tests\Unit\BaseTestCase {
 	public function test_str_to_camel_case(): void {
 		$string = "welcome~ to camel' case!!";
 		$expected_result = "welcomeToCamelCase";
-//		$string = "D'Angelo";
-//		$expected_result = "dAngelo";
 
 		//this method uses another method (str_to_words) from same file (string.php)
 		$result = \Cig\str_to_camel_case($string);
 
 		self::assertIsString($result);
 		self::assertSame($expected_result, $result);
-		// skipping international alphabet tests
+	}
+
+	/**
+	 * SKIP: international alphabets
+	 */
+	public function test_str_to_camel_case_international_alphabets(): void {
+		$int_string = 'Добро пожаловать в верблюжачью';
+		$expected_result = "ДоброПожаловатьВВерблюжачью";
+
+		// current method took one int alphabet test and only removed spaces
+		// $result = \Cig\str_to_camel_case();
+
+		self::markTestSkipped('**WIP** Revisit this test');
 	}
 
 	//TODO: expected this to break but this method goes ahead and turns

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -50,7 +50,6 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 		];
 	}
 
-	//TODO: look into method re:what defines human readable, caps/all lowercase/etc
 	/**
 	 * @dataProvider provide_str_case_data
 	 * @param $string
@@ -59,6 +58,7 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 	public function test_str_to_human_readable_camel($string, $expected_result): void {
 		$result = \Cig\str_to_human_readable($string);
 
+		self::assertIsString($result);
 		self::assertSame($expected_result, $result);
 	}
 

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -26,4 +26,14 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 		// note: not technically a 'fail' but incorrectly separates surnames with bicapital
 		self::assertSame($expected_result, $result);
 	}
+
+	public function test_str_to_human_readable_with_array(): void {
+		$array = ['spooky', 'scary', 'skeletons'];
+		// $expected_result = ;
+
+		$this->expectError();
+		$this->expectErrorMessage('Argument 1 passed to Cig\str_to_human_readable() must be of the type string, array given');
+
+		$result = \Cig\str_to_human_readable($array);
+	}
 }

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -1,9 +1,6 @@
 <?php
 
-namespace Cig\Tests\Unit;
-
-use PHPUnit\Framework\Error\Notice;
-use PHPUnit\Framework\Error\Warning;
+namespace Cig\Tests\Unit\Functions;
 
 class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -95,7 +95,7 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 		// $expected_result = ;
 
 		$this->expectError();
-		$this->expectErrorMessage('Argument 1 passed to Cig\str_to_human_readable() must be of the type string, array given');
+		$this->expectErrorMessage('Argument #1 ($string) must be of type string, array given');
 
 		$result = \Cig\str_to_human_readable($array);
 	}

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -54,4 +54,13 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 
 		self::assertSame($expected_result, $result);
 	}
+
+	public function test_str_to_human_readable_kebab(): void {
+		$string = 'kebab-case-pepper-tomato';
+		$expected_result = 'kebab case pepper tomato';
+
+		$result = \Cig\str_to_human_readable($string);
+
+		self::assertSame($expected_result, $result);
+	}
 }

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\Error\Warning;
 
 class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
+
 	//TODO: look into method re:what defines human readable, caps/all lowercase/etc
 	public function test_str_to_human_readable_camel(): void {
 		$string = "camelCaseStringTest!!";
@@ -13,6 +14,16 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 
 		$result = \Cig\str_to_human_readable($string);
 
+		self::assertSame($expected_result, $result);
+	}
+
+	public function test_str_to_human_readable_bicapital(): void {
+		$string = "danny-DeVito_";
+		$expected_result = "danny De Vito";
+
+		$result = \Cig\str_to_human_readable($string);
+
+		// note: not technically a 'fail' but incorrectly separates surnames with bicapital
 		self::assertSame($expected_result, $result);
 	}
 }

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -9,8 +9,8 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 
 	//TODO: look into method re:what defines human readable, caps/all lowercase/etc
 	public function test_str_to_human_readable_camel(): void {
-		$string = "camelCaseStringTest!!";
-		$expected_result = "camel Case String Test";
+		$string = 'camelCaseStringTest!!';
+		$expected_result = 'camel Case String Test';
 
 		$result = \Cig\str_to_human_readable($string);
 
@@ -18,8 +18,8 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 	}
 
 	public function test_str_to_human_readable_bicapital(): void {
-		$string = "danny-DeVito_";
-		$expected_result = "danny De Vito";
+		$string = 'danny-DeVito_';
+		$expected_result = 'danny De Vito';
 
 		$result = \Cig\str_to_human_readable($string);
 

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -4,9 +4,7 @@ namespace Cig\Tests\Unit\Functions;
 
 class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 
-	/**
-	 * @covers ::\Cig\str_to_human_readable
-	 *
+	/***
 	 * @return array Strings, expected results
 	 */
 	public function provide_str_case_data(): array {
@@ -59,11 +57,33 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 	 * @param $string
 	 * @param $expected_result
 	 */
-	public function test_str_to_human_readable_camel($string, $expected_result): void {
+	public function test_str_to_human_readable($string, $expected_result): void {
 		$result = \Cig\str_to_human_readable($string);
 
 		self::assertIsString($result);
 		self::assertSame($expected_result, $result);
+	}
+
+	/**
+	 * SKIP: replacing accents to names
+	 *
+	 */
+	public function test_str_to_human_readable_accents(): void {
+		$string = "dAngelo";
+		$expected_result = "d'angelo";
+
+		self::markTestSkipped('**WIP** Revisit this test');
+	}
+
+	/**
+	 * SKIP: bringing bicapital surnames together
+	 *
+	 */
+	public function test_str_to_human_readable_no_space_bicapital(): void {
+		$string = 'DannyDeVito';
+		$expected_result = 'Danny DeVito'; 
+
+		self::markTestSkipped('**WIP** Revisit this test');
 	}
 
 	/**

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -36,4 +36,13 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 
 		$result = \Cig\str_to_human_readable($array);
 	}
+
+	public function test_str_to_human_readable_pascal(): void {
+		$string = 'PascalCaseIsTheCase';
+		$expected_result = 'Pascal Case Is The Case';
+
+		$result = \Cig\str_to_human_readable($string);
+
+		self::assertSame($expected_result, $result);
+	}
 }

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -47,8 +47,8 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 	}
 
 	public function test_str_to_human_readable_snake(): void {
-		$string = "itsa_me_snake_case";
-		$expected_result = "itsa me snake case";
+		$string = 'itsa_me_snake_case';
+		$expected_result = 'itsa me snake case';
 
 		$result = \Cig\str_to_human_readable($string);
 

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -16,6 +16,7 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 				'camel Case String Test'
 			],
 			// note: not technically a 'fail' but incorrectly separates surnames with bicapital
+			// TODO: add option to pass in lowercase var for str_to_words?
 			'bicapital' => [
 				// string
 				'danny-DeVito_',
@@ -81,7 +82,7 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 	 */
 	public function test_str_to_human_readable_no_space_bicapital(): void {
 		$string = 'DannyDeVito';
-		$expected_result = 'Danny DeVito'; 
+		$expected_result = 'Danny DeVito';
 
 		self::markTestSkipped('**WIP** Revisit this test');
 	}

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -45,4 +45,13 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 
 		self::assertSame($expected_result, $result);
 	}
+
+	public function test_str_to_human_readable_snake(): void {
+		$string = "itsa_me_snake_case";
+		$expected_result = "itsa me snake case";
+
+		$result = \Cig\str_to_human_readable($string);
+
+		self::assertSame($expected_result, $result);
+	}
 }

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -7,10 +7,27 @@ use PHPUnit\Framework\Error\Warning;
 
 class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 
+	public function provide_str_case_data(): array {
+		return [
+			'camelCase' => [
+				// string
+				'camelCaseStringTest',
+				//  expected result
+				'camel Case String Test'
+			],
+		];
+	}
+
 	//TODO: look into method re:what defines human readable, caps/all lowercase/etc
-	public function test_str_to_human_readable_camel(): void {
-		$string = 'camelCaseStringTest!!';
-		$expected_result = 'camel Case String Test';
+
+	/**
+	 * @dataProvider provide_str_case_data
+	 * @param $string
+	 * @param $expected_result
+	 */
+	public function test_str_to_human_readable_camel($string, $expected_result): void {
+//		$string = 'camelCaseStringTest!!';
+//		$expected_result = 'camel Case String Test';
 
 		$result = \Cig\str_to_human_readable($string);
 

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -15,67 +15,48 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 				//  expected result
 				'camel Case String Test'
 			],
+			// note: not technically a 'fail' but incorrectly separates surnames with bicapital
+			'bicapital' => [
+				// string
+				'danny-DeVito_',
+				//  expected result
+				'danny De Vito'
+			],
+			'pascal' => [
+				// string
+				'PascalCaseIsTheCase',
+				//  expected result
+				'Pascal Case Is The Case'
+			],
+			'snake' => [
+				// string
+				'itsa_me_snake_case',
+				//  expected result
+				'itsa me snake case'
+			],
+			'kebab' => [
+				// string
+				'kebab-case-pepper-tomato',
+				//  expected result
+				'kebab case pepper tomato'
+			],
+			//TODO: another instance of integers turning into strings: expected or should this fail?
+			'integer' => [
+				// int
+				42,
+				//  expected result
+				'42'
+			],
 		];
 	}
 
 	//TODO: look into method re:what defines human readable, caps/all lowercase/etc
-
 	/**
 	 * @dataProvider provide_str_case_data
 	 * @param $string
 	 * @param $expected_result
 	 */
 	public function test_str_to_human_readable_camel($string, $expected_result): void {
-//		$string = 'camelCaseStringTest!!';
-//		$expected_result = 'camel Case String Test';
-
-		$result = \Cig\str_to_human_readable($string);
-
-		self::assertSame($expected_result, $result);
-	}
-
-	public function test_str_to_human_readable_bicapital(): void {
-		$string = 'danny-DeVito_';
-		$expected_result = 'danny De Vito';
-
-		$result = \Cig\str_to_human_readable($string);
-
-		// note: not technically a 'fail' but incorrectly separates surnames with bicapital
-		self::assertSame($expected_result, $result);
-	}
-
-	public function test_str_to_human_readable_pascal(): void {
-		$string = 'PascalCaseIsTheCase';
-		$expected_result = 'Pascal Case Is The Case';
-
-		$result = \Cig\str_to_human_readable($string);
-
-		self::assertSame($expected_result, $result);
-	}
-
-	public function test_str_to_human_readable_snake(): void {
-		$string = 'itsa_me_snake_case';
-		$expected_result = 'itsa me snake case';
-
-		$result = \Cig\str_to_human_readable($string);
-
-		self::assertSame($expected_result, $result);
-	}
-
-	public function test_str_to_human_readable_kebab(): void {
-		$string = 'kebab-case-pepper-tomato';
-		$expected_result = 'kebab case pepper tomato';
-
-		$result = \Cig\str_to_human_readable($string);
-
-		self::assertSame($expected_result, $result);
-	}
-
-	//TODO: another instance of integers turning into strings: expected or no?
-	public function test_str_to_human_readable_integer(): void {
-		$string = 42;
-		$expected_result = '42';
-
 		$result = \Cig\str_to_human_readable($string);
 
 		self::assertSame($expected_result, $result);

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -27,16 +27,6 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 		self::assertSame($expected_result, $result);
 	}
 
-	public function test_str_to_human_readable_with_array(): void {
-		$array = ['spooky', 'scary', 'skeletons'];
-		// $expected_result = ;
-
-		$this->expectError();
-		$this->expectErrorMessage('Argument 1 passed to Cig\str_to_human_readable() must be of the type string, array given');
-
-		$result = \Cig\str_to_human_readable($array);
-	}
-
 	public function test_str_to_human_readable_pascal(): void {
 		$string = 'PascalCaseIsTheCase';
 		$expected_result = 'Pascal Case Is The Case';
@@ -72,5 +62,15 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 		$result = \Cig\str_to_human_readable($string);
 
 		self::assertSame($expected_result, $result);
+	}
+
+	public function test_str_to_human_readable_with_array(): void {
+		$array = ['spooky', 'scary', 'skeletons'];
+		// $expected_result = ;
+
+		$this->expectError();
+		$this->expectErrorMessage('Argument 1 passed to Cig\str_to_human_readable() must be of the type string, array given');
+
+		$result = \Cig\str_to_human_readable($array);
 	}
 }

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -4,6 +4,11 @@ namespace Cig\Tests\Unit\Functions;
 
 class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 
+	/**
+	 * @covers ::\Cig\str_to_human_readable
+	 *
+	 * @return array Strings, expected results
+	 */
 	public function provide_str_case_data(): array {
 		return [
 			'camelCase' => [
@@ -48,6 +53,8 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 	}
 
 	/**
+	 * @covers ::\Cig\str_to_human_readable
+	 *
 	 * @dataProvider provide_str_case_data
 	 * @param $string
 	 * @param $expected_result
@@ -59,6 +66,9 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 		self::assertSame($expected_result, $result);
 	}
 
+	/**
+	 * @covers ::\Cig\str_to_human_readable
+	 */
 	public function test_str_to_human_readable_with_array(): void {
 		$array = ['spooky', 'scary', 'skeletons'];
 		// $expected_result = ;

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Cig\Tests\Unit;
+
+use PHPUnit\Framework\Error\Notice;
+use PHPUnit\Framework\Error\Warning;
+
+class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
+	//TODO: look into method re:what defines human readable, caps/all lowercase/etc
+	public function test_str_to_human_readable_camel(): void {
+		$string = "camelCaseStringTest!!";
+		$expected_result = "camel Case String Test";
+
+		$result = \Cig\str_to_human_readable($string);
+
+		self::assertSame($expected_result, $result);
+	}
+}

--- a/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
+++ b/tests/phpunit/Unit/functions/StrToHumanReadableTest.php
@@ -63,4 +63,14 @@ class StrToHumanReadableTest extends \Cig\Tests\Unit\BaseTestCase {
 
 		self::assertSame($expected_result, $result);
 	}
+
+	//TODO: another instance of integers turning into strings: expected or no?
+	public function test_str_to_human_readable_integer(): void {
+		$string = 42;
+		$expected_result = '42';
+
+		$result = \Cig\str_to_human_readable($string);
+
+		self::assertSame($expected_result, $result);
+	}
 }

--- a/tests/phpunit/Unit/functions/StrToKebabCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToKebabCaseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Cig\Tests\Unit;
+namespace Cig\Tests\Unit\Functions;
 
 
 class StrToKebabCaseTest extends \Cig\Tests\Unit\BaseTestCase {

--- a/tests/phpunit/Unit/functions/StrToKebabCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToKebabCaseTest.php
@@ -2,8 +2,12 @@
 
 namespace Cig\Tests\Unit;
 
+
 class StrToKebabCaseTest extends \Cig\Tests\Unit\BaseTestCase {
 
+	/**
+	 * @covers ::\Cig\str_to_kebab_case()
+	 */
 	public function test_str_to_kebab_case(): void {
 		$string = "welcome~ to *kebab case!!";
 		$expected_result = "welcome-to-kebab-case";

--- a/tests/phpunit/Unit/functions/StrToKebabCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToKebabCaseTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Cig\Tests\Unit;
+
+class StrToKebabCaseTest extends \Cig\Tests\Unit\BaseTestCase {
+
+	public function test_str_to_kebab_case(): void {
+		$string = "welcome~ to *kebab case!!";
+		$expected_result = "welcome-to-kebab-case";
+
+		//this method uses another method (str_to_words) from same file
+		$result = \Cig\str_to_kebab_case($string);
+
+		self::assertIsString($result);
+		self::assertSame($expected_result, $result);
+	}
+
+	//TODO: expected this to break but this method goes ahead and turns
+	// numbers into strings despite typescript asking for a string
+	public function test_number_to_kebab_case(): void {
+		$not_a_string = 1011;
+		// $expected_result = "don't expect result";
+
+		// TODO: showing test with string result to document. correct or refactor?
+		$method_result = '1011';
+
+		$result = \Cig\str_to_kebab_case($not_a_string);
+
+		self::assertIsString($result);
+		self::assertSame($method_result, $result);
+	}
+}

--- a/tests/phpunit/Unit/functions/StrToPascalCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToPascalCaseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Cig\Tests\Unit;
+namespace Cig\Tests\Unit\Functions;
 
 
 class StrToPascalCaseTest extends \Cig\Tests\Unit\BaseTestCase {

--- a/tests/phpunit/Unit/functions/StrToPascalCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToPascalCaseTest.php
@@ -2,8 +2,12 @@
 
 namespace Cig\Tests\Unit;
 
+
 class StrToPascalCaseTest extends \Cig\Tests\Unit\BaseTestCase {
 
+	/**
+	 * @covers ::\Cig\str_to_pascal_case()
+	 */
 	public function test_str_to_pascal_case(): void {
 		$string = "welcome~ to *pascal case!!";
 		$expected_result = "WelcomeToPascalCase";

--- a/tests/phpunit/Unit/functions/StrToPascalCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToPascalCaseTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Cig\Tests\Unit;
+
+class StrToPascalCaseTest extends \Cig\Tests\Unit\BaseTestCase {
+
+	public function test_str_to_pascal_case(): void {
+		$string = "welcome~ to *pascal case!!";
+		$expected_result = "WelcomeToPascalCase";
+
+		//this method uses another method (str_to_words) from same file
+		$result = \Cig\str_to_pascal_case($string);
+
+		self::assertIsString($result);
+		self::assertSame($expected_result, $result);
+	}
+
+	//TODO: expected this to break but this method goes ahead and turns
+	// numbers into strings despite typescript asking for a string
+	public function test_number_to_pascal_case(): void {
+		$not_a_string = 1011;
+		// $expected_result = "don't expect result";
+
+		// TODO: showing test with string result to document. correct or refactor?
+		$method_result = '1011';
+
+		$result = \Cig\str_to_pascal_case($not_a_string);
+
+		self::assertIsString($result);
+		self::assertSame($method_result, $result);
+	}
+}

--- a/tests/phpunit/Unit/functions/StrToSnakeCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToSnakeCaseTest.php
@@ -2,8 +2,12 @@
 
 namespace Cig\Tests\Unit;
 
+
 class StrToSnakeCaseTest extends \Cig\Tests\Unit\BaseTestCase {
 
+	/**
+	 * @covers ::\Cig\str_to_snake_case()
+	 */
 	public function test_str_to_snake_case(): void {
 		$string = "welcome~ to *snake case!!";
 		$expected_result = "welcome_to_snake_case";

--- a/tests/phpunit/Unit/functions/StrToSnakeCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToSnakeCaseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Cig\Tests\Unit;
+namespace Cig\Tests\Unit\Functions;
 
 
 class StrToSnakeCaseTest extends \Cig\Tests\Unit\BaseTestCase {

--- a/tests/phpunit/Unit/functions/StrToSnakeCaseTest.php
+++ b/tests/phpunit/Unit/functions/StrToSnakeCaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Cig\Tests\Unit;
+
+class StrToSnakeCaseTest extends \Cig\Tests\Unit\BaseTestCase {
+
+	public function test_str_to_snake_case(): void {
+		$string = "welcome~ to *snake case!!";
+		$expected_result = "welcome_to_snake_case";
+
+		//this method uses another method (str_to_words) from same file
+		$result = \Cig\str_to_snake_case($string);
+
+		self::assertIsString($result);
+		self::assertSame($expected_result, $result);
+	}
+}

--- a/tests/phpunit/Unit/functions/StrToWordsTest.php
+++ b/tests/phpunit/Unit/functions/StrToWordsTest.php
@@ -87,13 +87,42 @@ class StrToWordsTest extends \Cig\Tests\Unit\BaseTestCase {
 		self::assertSame($expected_result, $result);
 	}
 
-//		public function test_str_to_words_punctuation(): void {
-//			$string = '';
-//			$lowercase = '';
-//			$remove_punctuation = '';
-//
-//			$result = \Cig\str_to_words($string);
-//
-//			self::assertTrue(true);
-//		}
+	public function test_str_to_words_punctuation(): void {
+		$string = 'What?? _Are-we-doing. In the shadows.';
+		$lower = FALSE; //default
+		$remove_punctuation = FALSE;
+
+		$expected_result = [
+			'What??',
+			'_',
+			'Are-we-doing.',
+			'In',
+			'the',
+			'shadows.',
+		];
+		$result = \Cig\str_to_words($string);
+
+		self::assertIsArray($result);
+		// self::assertSame($expected_result, $result);
+	}
+
+	public function test_str_to_words_question_mark(): void {
+		$string = 'What?? Are we doing. In the shadows.';
+		$lower = FALSE; //default
+		$remove_punctuation = FALSE;
+
+		//		$expected_result = [
+		//			'What??',
+		//			'Are',
+		//			'we',
+		//			'doing.',
+		//			'In',
+		//			'the',
+		//			'shadows.',
+		//		];
+
+		$result = \Cig\str_to_words($string);
+
+		self::markTestSkipped('**WIP** Revisit this test — Question marks are punctuation but always treated under regex and thus always removed in spite of argument');
+	}
 }

--- a/tests/phpunit/Unit/functions/StrToWordsTest.php
+++ b/tests/phpunit/Unit/functions/StrToWordsTest.php
@@ -2,133 +2,119 @@
 
 namespace Cig\Tests\Unit\Functions;
 
-//TODO: string helpers are really stepping on each other in string.php
-
 class StrToWordsTest extends \Cig\Tests\Unit\BaseTestCase {
 
-	public function provide_str_to_words_data(): array {
-		return [
-			// dataProvider to come
+	public function test_str_to_words(): void {
+		$string = 'ConvertCamelCaseToMultipleWords';
+		$expected_result = [
+			'Convert',
+			'Camel',
+			'Case',
+			'To',
+			'Multiple',
+			'Words',
 		];
+
+		$result = \Cig\str_to_words($string);
+
+		self::assertIsArray($result);
+		self::assertSame($expected_result, $result);
 	}
 
-public
-function test_str_to_words(): void {
-	$string = 'ConvertCamelCaseToMultipleWords';
-	$expected_result = [
-		'Convert',
-		'Camel',
-		'Case',
-		'To',
-		'Multiple',
-		'Words',
-	];
+	public function test_str_to_words_lowercase(): void {
+		$string = 'What We Do In The Shadows';
+		$lower = FALSE;
+		$expected_result = [
+			'What',
+			'We',
+			'Do',
+			'In',
+			'The',
+			'Shadows',
+		];
 
-	$result = \Cig\str_to_words($string);
+		$result = \Cig\str_to_words($string, $lower);
 
-	self::assertIsArray($result);
-	self::assertSame($expected_result, $result);
-}
+		self::assertIsArray($result);
+		self::assertSame($expected_result, $result);
 
-public
-function test_str_to_words_lowercase(): void {
-	$string = 'What We Do In The Shadows';
-	$lower = FALSE;
-	$expected_result = [
-		'What',
-		'We',
-		'Do',
-		'In',
-		'The',
-		'Shadows',
-	];
+	}
 
-	$result = \Cig\str_to_words($string, $lower);
+	public function test_str_to_words_not_lowercase(): void {
+		$string = 'What We Do In The Shadows';
+		$lower = TRUE;
+		$expected_result = [
+			'what',
+			'we',
+			'do',
+			'in',
+			'the',
+			'shadows',
+		];
 
-	self::assertIsArray($result);
-	self::assertSame($expected_result, $result);
+		$result = \Cig\str_to_words($string, $lower);
 
-}
+		self::assertIsArray($result);
+		self::assertSame($expected_result, $result);
+	}
 
-public
-function test_str_to_words_not_lowercase(): void {
-	$string = 'What We Do In The Shadows';
-	$lower = TRUE;
-	$expected_result = [
-		'what',
-		'we',
-		'do',
-		'in',
-		'the',
-		'shadows',
-	];
+	public function test_str_to_words_no_punctuation(): void {
+		$string = 'What?? _ Are-we-doing. In the shadows.';
+		$lower = FALSE; //default
+		$remove_punctuation = TRUE;
 
-	$result = \Cig\str_to_words($string, $lower);
+		$expected_result = [
+			'What',
+			'Are',
+			'we',
+			'doing',
+			'In',
+			'the',
+			'shadows',
+		];
 
-	self::assertIsArray($result);
-	self::assertSame($expected_result, $result);
-}
+		$result = \Cig\str_to_words($string, $lower, $remove_punctuation);
 
-public
-function test_str_to_words_no_punctuation(): void {
-	$string = 'What?? _ Are-we-doing. In the shadows.';
-	$lower = FALSE; //default
-	$remove_punctuation = TRUE;
+		self::assertIsArray($result);
+		self::assertSame($expected_result, $result);
+	}
 
-	$expected_result = [
-		'What',
-		'Are',
-		'we',
-		'doing',
-		'In',
-		'the',
-		'shadows',
-	];
+	public function test_str_to_words_punctuation(): void {
+		$string = 'What?? _Are-we-doing. In the shadows.';
+		$lower = FALSE; //default
+		$remove_punctuation = FALSE;
 
-	$result = \Cig\str_to_words($string, $lower, $remove_punctuation);
+		$expected_result = [
+			'What??',
+			'_',
+			'Are-we-doing.',
+			'In',
+			'the',
+			'shadows.',
+		];
+		$result = \Cig\str_to_words($string);
 
-	self::assertIsArray($result);
-	self::assertSame($expected_result, $result);
-}
+		self::assertIsArray($result);
+		// self::assertSame($expected_result, $result);
+	}
 
-public
-function test_str_to_words_punctuation(): void {
-	$string = 'What?? _Are-we-doing. In the shadows.';
-	$lower = FALSE; //default
-	$remove_punctuation = FALSE;
+	public function test_str_to_words_question_mark(): void {
+		$string = 'What?? Are we doing. In the shadows.';
+		$lower = FALSE; //default
+		$remove_punctuation = FALSE;
 
-	$expected_result = [
-		'What??',
-		'_',
-		'Are-we-doing.',
-		'In',
-		'the',
-		'shadows.',
-	];
-	$result = \Cig\str_to_words($string);
+		//		$expected_result = [
+		//			'What??',
+		//			'Are',
+		//			'we',
+		//			'doing.',
+		//			'In',
+		//			'the',
+		//			'shadows.',
+		//		];
 
-	self::assertIsArray($result);
-	// self::assertSame($expected_result, $result);
-}
+		$result = \Cig\str_to_words($string);
 
-public
-function test_str_to_words_question_mark(): void {
-	$string = 'What?? Are we doing. In the shadows.';
-	$lower = FALSE; //default
-	$remove_punctuation = FALSE;
-
-	//		$expected_result = [
-	//			'What??',
-	//			'Are',
-	//			'we',
-	//			'doing.',
-	//			'In',
-	//			'the',
-	//			'shadows.',
-	//		];
-
-	$result = \Cig\str_to_words($string);
-
-	self::markTestSkipped('**WIP** Revisit this test — Question marks are punctuation but always treated under regex and thus always removed in spite of argument');
-}
+		self::markTestSkipped('**WIP** Revisit this test — Question marks are punctuation but always treated under regex and thus always removed in spite of argument');
+	}
 }

--- a/tests/phpunit/Unit/functions/StrToWordsTest.php
+++ b/tests/phpunit/Unit/functions/StrToWordsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Cig\Tests\Unit\Functions;
+
+//TODO: string helpers are really stepping on each other in string.php
+
+class StrToWordsTest extends \Cig\Tests\Unit\BaseTestCase {
+
+	//	public function provide_str_to words_data(): array {
+	//		return [
+	//					 dataProvider to come
+	//			];
+	//	}
+
+	public function test_str_to_words(): void {
+		$string = 'ConvertCamelCaseToMultipleWords';
+		$expected_result = [
+			'Convert',
+			'Camel',
+			'Case',
+			'To',
+			'Multiple',
+			'Words',
+		];
+
+		$result = \Cig\str_to_words($string);
+
+		self::assertIsArray($result);
+		self::assertSame($expected_result, $result);
+	}
+
+	public function test_str_to_words_lowercase(): void {
+		$string = 'What We Do In The Shadows';
+		$lower = FALSE;
+		$expected_result = [
+			'What',
+			'We',
+			'Do',
+			'In',
+			'The',
+			'Shadows',
+		];
+
+		$result = \Cig\str_to_words($string, $lower);
+
+		self::assertIsArray($result);
+		self::assertSame($expected_result, $result);
+
+	}
+
+	public function test_str_to_words_not_lowercase(): void {
+		$string = 'What We Do In The Shadows';
+		$lower = TRUE;
+		$expected_result = [
+			'what',
+			'we',
+			'do',
+			'in',
+			'the',
+			'shadows',
+		];
+
+		$result = \Cig\str_to_words($string, $lower);
+
+		self::assertIsArray($result);
+		self::assertSame($expected_result, $result);
+	}
+
+	public function test_str_to_words_no_punctuation(): void {
+		$string = 'What?? _ Are-we-doing. In the shadows.';
+		$lower = FALSE; //default
+		$remove_punctuation = TRUE;
+
+		$expected_result = [
+			'What',
+			'Are',
+			'we',
+			'doing',
+			'In',
+			'the',
+			'shadows',
+		];
+
+		$result = \Cig\str_to_words($string, $lower, $remove_punctuation);
+
+		self::assertIsArray($result);
+		self::assertSame($expected_result, $result);
+	}
+
+//		public function test_str_to_words_punctuation(): void {
+//			$string = '';
+//			$lowercase = '';
+//			$remove_punctuation = '';
+//
+//			$result = \Cig\str_to_words($string);
+//
+//			self::assertTrue(true);
+//		}
+}

--- a/tests/phpunit/Unit/functions/StrToWordsTest.php
+++ b/tests/phpunit/Unit/functions/StrToWordsTest.php
@@ -6,11 +6,11 @@ namespace Cig\Tests\Unit\Functions;
 
 class StrToWordsTest extends \Cig\Tests\Unit\BaseTestCase {
 
-	public function provide_str_to words_data(): array {
-	//			return [
-	////						 dataProvider to come
-	//				];
-	//		}
+	public function provide_str_to_words_data(): array {
+		return [
+			// dataProvider to come
+		];
+	}
 
 public
 function test_str_to_words(): void {

--- a/tests/phpunit/Unit/functions/StrToWordsTest.php
+++ b/tests/phpunit/Unit/functions/StrToWordsTest.php
@@ -6,123 +6,129 @@ namespace Cig\Tests\Unit\Functions;
 
 class StrToWordsTest extends \Cig\Tests\Unit\BaseTestCase {
 
-	//	public function provide_str_to words_data(): array {
-	//		return [
-	//					 dataProvider to come
-	//			];
-	//	}
+	public function provide_str_to words_data(): array {
+	//			return [
+	////						 dataProvider to come
+	//				];
+	//		}
 
-	public function test_str_to_words(): void {
-		$string = 'ConvertCamelCaseToMultipleWords';
-		$expected_result = [
-			'Convert',
-			'Camel',
-			'Case',
-			'To',
-			'Multiple',
-			'Words',
-		];
+public
+function test_str_to_words(): void {
+	$string = 'ConvertCamelCaseToMultipleWords';
+	$expected_result = [
+		'Convert',
+		'Camel',
+		'Case',
+		'To',
+		'Multiple',
+		'Words',
+	];
 
-		$result = \Cig\str_to_words($string);
+	$result = \Cig\str_to_words($string);
 
-		self::assertIsArray($result);
-		self::assertSame($expected_result, $result);
-	}
+	self::assertIsArray($result);
+	self::assertSame($expected_result, $result);
+}
 
-	public function test_str_to_words_lowercase(): void {
-		$string = 'What We Do In The Shadows';
-		$lower = FALSE;
-		$expected_result = [
-			'What',
-			'We',
-			'Do',
-			'In',
-			'The',
-			'Shadows',
-		];
+public
+function test_str_to_words_lowercase(): void {
+	$string = 'What We Do In The Shadows';
+	$lower = FALSE;
+	$expected_result = [
+		'What',
+		'We',
+		'Do',
+		'In',
+		'The',
+		'Shadows',
+	];
 
-		$result = \Cig\str_to_words($string, $lower);
+	$result = \Cig\str_to_words($string, $lower);
 
-		self::assertIsArray($result);
-		self::assertSame($expected_result, $result);
+	self::assertIsArray($result);
+	self::assertSame($expected_result, $result);
 
-	}
+}
 
-	public function test_str_to_words_not_lowercase(): void {
-		$string = 'What We Do In The Shadows';
-		$lower = TRUE;
-		$expected_result = [
-			'what',
-			'we',
-			'do',
-			'in',
-			'the',
-			'shadows',
-		];
+public
+function test_str_to_words_not_lowercase(): void {
+	$string = 'What We Do In The Shadows';
+	$lower = TRUE;
+	$expected_result = [
+		'what',
+		'we',
+		'do',
+		'in',
+		'the',
+		'shadows',
+	];
 
-		$result = \Cig\str_to_words($string, $lower);
+	$result = \Cig\str_to_words($string, $lower);
 
-		self::assertIsArray($result);
-		self::assertSame($expected_result, $result);
-	}
+	self::assertIsArray($result);
+	self::assertSame($expected_result, $result);
+}
 
-	public function test_str_to_words_no_punctuation(): void {
-		$string = 'What?? _ Are-we-doing. In the shadows.';
-		$lower = FALSE; //default
-		$remove_punctuation = TRUE;
+public
+function test_str_to_words_no_punctuation(): void {
+	$string = 'What?? _ Are-we-doing. In the shadows.';
+	$lower = FALSE; //default
+	$remove_punctuation = TRUE;
 
-		$expected_result = [
-			'What',
-			'Are',
-			'we',
-			'doing',
-			'In',
-			'the',
-			'shadows',
-		];
+	$expected_result = [
+		'What',
+		'Are',
+		'we',
+		'doing',
+		'In',
+		'the',
+		'shadows',
+	];
 
-		$result = \Cig\str_to_words($string, $lower, $remove_punctuation);
+	$result = \Cig\str_to_words($string, $lower, $remove_punctuation);
 
-		self::assertIsArray($result);
-		self::assertSame($expected_result, $result);
-	}
+	self::assertIsArray($result);
+	self::assertSame($expected_result, $result);
+}
 
-	public function test_str_to_words_punctuation(): void {
-		$string = 'What?? _Are-we-doing. In the shadows.';
-		$lower = FALSE; //default
-		$remove_punctuation = FALSE;
+public
+function test_str_to_words_punctuation(): void {
+	$string = 'What?? _Are-we-doing. In the shadows.';
+	$lower = FALSE; //default
+	$remove_punctuation = FALSE;
 
-		$expected_result = [
-			'What??',
-			'_',
-			'Are-we-doing.',
-			'In',
-			'the',
-			'shadows.',
-		];
-		$result = \Cig\str_to_words($string);
+	$expected_result = [
+		'What??',
+		'_',
+		'Are-we-doing.',
+		'In',
+		'the',
+		'shadows.',
+	];
+	$result = \Cig\str_to_words($string);
 
-		self::assertIsArray($result);
-		// self::assertSame($expected_result, $result);
-	}
+	self::assertIsArray($result);
+	// self::assertSame($expected_result, $result);
+}
 
-	public function test_str_to_words_question_mark(): void {
-		$string = 'What?? Are we doing. In the shadows.';
-		$lower = FALSE; //default
-		$remove_punctuation = FALSE;
+public
+function test_str_to_words_question_mark(): void {
+	$string = 'What?? Are we doing. In the shadows.';
+	$lower = FALSE; //default
+	$remove_punctuation = FALSE;
 
-		//		$expected_result = [
-		//			'What??',
-		//			'Are',
-		//			'we',
-		//			'doing.',
-		//			'In',
-		//			'the',
-		//			'shadows.',
-		//		];
+	//		$expected_result = [
+	//			'What??',
+	//			'Are',
+	//			'we',
+	//			'doing.',
+	//			'In',
+	//			'the',
+	//			'shadows.',
+	//		];
 
-		$result = \Cig\str_to_words($string);
+	$result = \Cig\str_to_words($string);
 
-		self::markTestSkipped('**WIP** Revisit this test — Question marks are punctuation but always treated under regex and thus always removed in spite of argument');
-	}
+	self::markTestSkipped('**WIP** Revisit this test — Question marks are punctuation but always treated under regex and thus always removed in spite of argument');
+}
 }


### PR DESCRIPTION
- tests for `is_assoc`
- marked mixed array test to skip/revisit later, expected mixed array to fail but it seems if there are any assoc keys in the array it's considered true/valid? noting to confirm later
- (note: this branch is built off the one before so this includes commits from other PRs currently in open)

<img src="https://media4.giphy.com/media/QEhmoTK7GPTkA/giphy.gif" alt="ein the data dog" width="350px;"/>